### PR TITLE
Set base path to / for self-hosted deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,9 +27,8 @@ export default defineConfig(async ({ command }) => {
       },
     },
     root: path.resolve(import.meta.dirname, "client"),
-    // Use /tinkerlab/ base path only for production builds (GitHub Pages)
-    // Use / for development to avoid HMR issues
-    base: command === "build" ? "/tinkerlab/" : "/",
+    // Use / for both development and production for self-hosted deployment
+    base: "/",
     build: {
       outDir: path.resolve(import.meta.dirname, "dist/public"),
       emptyOutDir: true,


### PR DESCRIPTION
Changes the Vite configuration to use "/" as the base path for both development and production builds instead of conditionally using "/tinkerlab/" for production.

Updates the comment to reflect that this configuration is for self-hosted deployment rather than GitHub Pages deployment.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/80d4058954644e3fab7417a1b2ddf2a9/vibe-space)

👀 [Preview Link](https://80d4058954644e3fab7417a1b2ddf2a9-vibe-space.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>80d4058954644e3fab7417a1b2ddf2a9</projectId>-->
<!--<branchName>vibe-space</branchName>-->