### PR TITLE
Update base path for GitHub Pages deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,8 +27,8 @@ export default defineConfig(async ({ command }) => {
       },
     },
     root: path.resolve(import.meta.dirname, "client"),
-    // Use / for both development and production for self-hosted deployment
-    base: "/",
+    // Use /tinkerlab/ for GitHub Pages deployment
+    base: "/tinkerlab/",
     build: {
       outDir: path.resolve(import.meta.dirname, "dist/public"),
       emptyOutDir: true,


### PR DESCRIPTION
Changes the Vite configuration base path from "/" to "/tinkerlab/" for GitHub Pages deployment.

Updates the comment to reflect the new deployment target (GitHub Pages instead of self-hosted deployment).

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/80d4058954644e3fab7417a1b2ddf2a9/echo-lab)

👀 [Preview Link](https://80d4058954644e3fab7417a1b2ddf2a9-echo-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>80d4058954644e3fab7417a1b2ddf2a9</projectId>-->
<!--<branchName>echo-lab</branchName>-->