### PR TITLE
Update Node.js runtime to version 18.x in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "installCommand": "npm install",
   "functions": {
     "api/*.js": {
-      "runtime": "@vercel/node"
+      "runtime": "@vercel/node@18.x"
     }
   },
   "routes": [


### PR DESCRIPTION
Updates the Node.js runtime specification in vercel.json from "@vercel/node" to "@vercel/node@18.x" for API functions.

This change explicitly pins the runtime to Node.js version 18.x for all API routes.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e514de16e08e4d87a62be2863af34745/pixel-nest)

👀 [Preview Link](https://e514de16e08e4d87a62be2863af34745-pixel-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e514de16e08e4d87a62be2863af34745</projectId>-->
<!--<branchName>pixel-nest</branchName>-->