### PR TITLE
Update Vercel runtime from @vercel/node@18.x to nodejs18.x

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
   "installCommand": "npm install",
   "functions": {
     "api/*.js": {
-      "runtime": "@vercel/node@18.x"
+      "runtime": "nodejs18.x"
     }
   },
   "routes": [


### PR DESCRIPTION
Updates the runtime configuration in vercel.json for API functions.

Changes:
- Changed runtime from "@vercel/node@18.x" to "nodejs18.x" for api/*.js functions

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 5`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e514de16e08e4d87a62be2863af34745/neon-zone)

👀 [Preview Link](https://e514de16e08e4d87a62be2863af34745-neon-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e514de16e08e4d87a62be2863af34745</projectId>-->
<!--<branchName>neon-zone</branchName>-->